### PR TITLE
Add basic React workout planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Fit
+
+This repository contains a minimal React-based fitness planner. Open `index.html` in your browser to try it out. The app lets you:
+
+- Enter personal settings (weight, height, goal).
+- Add exercises with sets, reps, weight and assign them to specific days.
+- Browse workouts in a monthly calendar view and navigate between months.
+
+It uses React and Babel from public CDNs, so there's no build step or dependencies. You can enhance it further by adding persistence or additional features.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,121 @@
+const { useState } = React;
+
+function App() {
+  const [exercises, setExercises] = useState([]);
+  const [settings, setSettings] = useState({ weight: '', height: '', goal: '' });
+  const [calendar, setCalendar] = useState({});
+  const [currentMonth, setCurrentMonth] = useState(new Date());
+
+  const addExercise = (e) => {
+    e.preventDefault();
+    const form = e.target;
+    const newExercise = {
+      name: form.name.value,
+      sets: form.sets.value,
+      reps: form.reps.value,
+      weight: form.weight.value,
+      day: form.day.value
+    };
+    setExercises([...exercises, newExercise]);
+    setCalendar({
+      ...calendar,
+      [newExercise.day]: [...(calendar[newExercise.day] || []), newExercise]
+    });
+    form.reset();
+  };
+
+  const updateSetting = (e) => {
+    const { name, value } = e.target;
+    setSettings({ ...settings, [name]: value });
+  };
+
+  const daysInMonth = () => {
+    const year = currentMonth.getFullYear();
+    const month = currentMonth.getMonth();
+    return new Date(year, month + 1, 0).getDate();
+  };
+
+  const nextMonth = () => {
+    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1));
+  };
+
+  const prevMonth = () => {
+    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1));
+  };
+
+  const monthDays = () => {
+    const total = daysInMonth();
+    const year = currentMonth.getFullYear();
+    const month = currentMonth.getMonth();
+    return Array.from({ length: total }, (_, i) => new Date(year, month, i + 1));
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>Fit Planner</h1>
+      </header>
+
+      <section>
+        <h2>Personal Settings</h2>
+        <input
+          type="text"
+          name="weight"
+          placeholder="Weight"
+          value={settings.weight}
+          onChange={updateSetting}
+        />
+        <input
+          type="text"
+          name="height"
+          placeholder="Height"
+          value={settings.height}
+          onChange={updateSetting}
+        />
+        <input
+          type="text"
+          name="goal"
+          placeholder="Goal"
+          value={settings.goal}
+          onChange={updateSetting}
+        />
+      </section>
+
+      <section>
+        <h2>Add Exercise</h2>
+        <form onSubmit={addExercise}>
+          <input name="name" placeholder="Exercise" required />
+          <input name="sets" placeholder="Sets" type="number" min="1" required />
+          <input name="reps" placeholder="Reps" type="number" min="1" required />
+          <input name="weight" placeholder="Weight" />
+          <select name="day" required>
+            {monthDays().map(d => (
+              <option key={d.toDateString()} value={d.toDateString()}>{d.getDate()}</option>
+            ))}
+          </select>
+          <button type="submit">Add</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>{currentMonth.toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
+        <button onClick={prevMonth}>Prev</button>
+        <button onClick={nextMonth}>Next</button>
+        <div className="calendar">
+          {monthDays().map(date => (
+            <div key={date.toDateString()} className="day">
+              <header>{date.getDate()}</header>
+              {(calendar[date.toDateString()] || []).map((ex, idx) => (
+                <div key={idx} className="exercise">
+                  {ex.name} {ex.sets}x{ex.reps} {ex.weight}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fit Planner</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f7f7f7;
+  margin: 0;
+  padding: 0;
+}
+
+#root {
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 5px;
+  margin-top: 20px;
+}
+
+.day {
+  border: 1px solid #ccc;
+  min-height: 80px;
+  padding: 5px;
+}
+
+.day header {
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+
+form {
+  margin-bottom: 10px;
+}
+
+input, select {
+  margin-right: 5px;
+}
+
+.exercise {
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
## Summary
- add HTML page that loads React and Babel from CDNs
- add a simple React fitness planner in `app.js`
- style the calendar and layout in `style.css`
- update README with instructions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68881d76d6e883299387fbfe79b36968