### PR TITLE
Add Vite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # Fit
 
-This repository contains a minimal React-based fitness planner. Open `index.html` in your browser to try it out. The app lets you:
+This repository contains a minimal React-based fitness planner built with [Vite](https://vitejs.dev/).
+
+## Features
 
 - Enter personal settings (weight, height, goal).
 - Add exercises with sets, reps, weight and assign them to specific days.
 - Browse workouts in a monthly calendar view and navigate between months.
 
-It uses React and Babel from public CDNs, so there's no build step or dependencies. You can enhance it further by adding persistence or additional features.
+## Getting Started
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+3. Open the printed URL in your browser to view the app.
+
+Use `npm run build` to create a production build.

--- a/index.html
+++ b/index.html
@@ -4,13 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fit Planner</title>
-  <link rel="stylesheet" href="style.css" />
-  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <div id="root"></div>
-  <script type="text/babel" src="app.js"></script>
+  <script type="module" src="/src/main.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fit",
+  "version": "1.0.0",
+  "description": "Minimal React-based fitness planner",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No test specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.1.0"
+  },
+  "type": "module"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-const { useState } = React;
+import React, { useState } from 'react';
 
 function App() {
   const [exercises, setExercises] = useState([]);
@@ -118,4 +118,4 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root'));
+export default App;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize npm and gitignore
- migrate React code to Vite
- configure Vite and add entrypoints
- update README with usage instructions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882521d5488329b09734a255f3f442